### PR TITLE
Fix training and generation after model API change

### DIFF
--- a/model/sequencer.py
+++ b/model/sequencer.py
@@ -52,7 +52,7 @@ class Sequencer:
         self.model.eval()
         with no_grad():
             for i in trange(length):
-                probs = self.model(token_ids, ignore_ids)
+                probs, _ = self.model(token_ids, ignore_ids)
                 next_id = self.gen_next_token(probs, idx)
                 tokens.append(self.tokenizer.get_byte(str(next_id.item())))
                 token_ids, ignore_ids, idx = self.update_token_ids(

--- a/model/trainer.py
+++ b/model/trainer.py
@@ -94,7 +94,7 @@ class Trainer:
             self.model.zero_grad()
             self.opt.zero_grad()
 
-        y_pred = self.model(x, ignore)
+        y_pred, _ = self.model(x, ignore)
         y_pred = y_pred.view(-1, y_pred.size(-1))
         y = y.view(-1)
         loss = self.crit(y_pred, y)


### PR DESCRIPTION
## Summary
- adjust Trainer and Sequencer for new `(logits, hidden_states)` GPT output

## Testing
- `python -m py_compile train.py generate.py preprocessing/*.py model/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685acf74284083248a9b9d73ce3148c0