### PR TITLE
Strengthen CLI error handling

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -1,6 +1,8 @@
 """Command-line interface for generating text with a trained GPT model."""
 
 import argparse
+import os
+import sys
 
 from miniyaml import load as load_yaml
 
@@ -12,6 +14,7 @@ except ModuleNotFoundError as exc:
 from model.tokenizer import BytePairTokenizer
 from model.sequencer import Sequencer
 from model.model import GPT
+from sentinel import panic
 
 
 # Default configuration path. The repository stores configuration files under
@@ -23,17 +26,43 @@ def main():
     """Run the text generation utility from the command line."""
 
     parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--conf', default=confpath)
     parser.add_argument('-l', '--length', type=int, default=128)
     args = parser.parse_args()
     length = args.length
 
-    confs = load_yaml(confpath)
-    model = GPT(**confs['model'])
-    model.load_state_dict(load(confs['pretrained_model'])) 
-    tokenizer = BytePairTokenizer.load(confs['trained_tokenizer'])
+    try:
+        confs = load_yaml(args.conf)
+    except FileNotFoundError:
+        panic(f"Config not found: {args.conf}")
+    except Exception as exc:  # pragma: no cover - unexpected parse errors
+        panic(f"Failed to load config: {exc}")
+
+    model_path = confs.get('pretrained_model')
+    if not os.path.isfile(model_path):
+        panic(f"Model file missing: {model_path}")
+
+    try:
+        model = GPT(**confs['model'])
+        model.load_state_dict(load(model_path))
+    except Exception as exc:
+        panic(f"Could not load model: {exc}")
+
+    tok_path = confs.get('trained_tokenizer')
+    if not os.path.isdir(tok_path):
+        panic(f"Tokenizer data missing: {tok_path}")
+
+    try:
+        tokenizer = BytePairTokenizer.load(tok_path)
+    except Exception as exc:
+        panic(f"Could not load tokenizer: {exc}")
 
     sequencer = Sequencer(model, tokenizer, **confs['sequencer'])
-    sequence = sequencer.generate_sequence(length)
+    try:
+        sequence = sequencer.generate_sequence(length)
+    except Exception as exc:
+        panic(f"Generation failed: {exc}")
+
     print(sequence)
 
 

--- a/preprocessing/tokenize_dataset.py
+++ b/preprocessing/tokenize_dataset.py
@@ -4,11 +4,14 @@ from argparse import ArgumentParser
 from multiprocessing import Pool
 from itertools import repeat
 from typing import List
+import os
+import sys
 
 from nltk import wordpunct_tokenize, sent_tokenize
 from tqdm import tqdm
 
 from model.tokenizer import BytePairTokenizer, count_byte_freqs
+from sentinel import panic
 
 
 def tokenize_file(filepath: str, outdir: str, tokenizer: BytePairTokenizer,
@@ -22,7 +25,10 @@ def tokenize_file(filepath: str, outdir: str, tokenizer: BytePairTokenizer,
     """
 
     outpath = f"{outdir}/{filepath.split('/')[-1]}"
-    lines = sent_tokenize(open(filepath, encoding='utf-8-sig').read())
+    try:
+        lines = sent_tokenize(open(filepath, encoding='utf-8-sig').read())
+    except FileNotFoundError:
+        panic(f"Input file not found: {filepath}")
 
     tokens = []
     for line in lines:
@@ -30,6 +36,7 @@ def tokenize_file(filepath: str, outdir: str, tokenizer: BytePairTokenizer,
             tokens += get_line_ids(line, tokenizer)
 
     start, end = 0, line_length 
+    os.makedirs(outdir, exist_ok=True)
     with open(outpath, 'w') as outfile:
         while start < len(tokens):
             if len(tokens[start:end]) == line_length:
@@ -81,8 +88,14 @@ def main():
     inpath = args.inpath
     jobs = args.jobs
 
-    filepaths = [line.strip() for line in open(inpath).readlines()]
-    tokenizer = BytePairTokenizer.load(checkpoint)
+    try:
+        filepaths = [line.strip() for line in open(inpath).readlines()]
+    except FileNotFoundError:
+        panic(f"File list not found: {inpath}")
+    try:
+        tokenizer = BytePairTokenizer.load(checkpoint)
+    except Exception as exc:
+        panic(f"Failed to load tokenizer: {exc}")
 
     progress = tqdm(total=len(filepaths))
     start, end = 0, jobs
@@ -90,16 +103,19 @@ def main():
 
         paths = filepaths[start:end]
 
-        with Pool(jobs) as pool:
-            pool.starmap(
-                tokenize_file, 
-                zip(
-                    paths, 
-                    repeat(outdir), 
-                    repeat(tokenizer),
-                    repeat(line_length)
+        try:
+            with Pool(jobs) as pool:
+                pool.starmap(
+                    tokenize_file,
+                    zip(
+                        paths,
+                        repeat(outdir),
+                        repeat(tokenizer),
+                        repeat(line_length)
+                    )
                 )
-            )
+        except Exception as exc:
+            panic(f"Worker failure: {exc}")
 
         progress.update(len(paths))
         start += jobs

--- a/preprocessing/train_bpe.py
+++ b/preprocessing/train_bpe.py
@@ -1,8 +1,11 @@
 """Utility script for training a byte-pair tokenizer."""
 
 from argparse import ArgumentParser
+import sys
+import os
 
 from model.tokenizer import BytePairTokenizer
+from sentinel import panic
 
 
 def main():
@@ -19,9 +22,19 @@ def main():
     merges = args.merges
     mincount = args.mincount
 
-    filepaths = [path.strip() for path in open(inpath).readlines()]
-    tokenizer = BytePairTokenizer.train_bpe(filepaths, mincount, merges)
-    tokenizer.save(f'{outpath}')
+    try:
+        filepaths = [path.strip() for path in open(inpath).readlines()]
+    except FileNotFoundError:
+        panic(f"File list not found: {inpath}")
+    try:
+        tokenizer = BytePairTokenizer.train_bpe(filepaths, mincount, merges)
+    except Exception as exc:
+        panic(f"Tokenizer training failed: {exc}")
+    os.makedirs(outpath, exist_ok=True)
+    try:
+        tokenizer.save(f'{outpath}')
+    except Exception as exc:
+        panic(f"Failed to save tokenizer: {exc}")
 
 
 if __name__ == '__main__':

--- a/sentinel.py
+++ b/sentinel.py
@@ -1,0 +1,9 @@
+"""Sentinel helpers for graceful failure."""
+
+import sys
+
+
+def panic(message: str) -> None:
+    """Print error with emoji and exit."""
+    print(f"\N{bomb} {message}", file=sys.stderr)
+    raise SystemExit(1)

--- a/train.py
+++ b/train.py
@@ -3,6 +3,7 @@
 import argparse
 import shutil
 import os
+import sys
 
 from miniyaml import load as load_yaml
 
@@ -19,6 +20,7 @@ except ModuleNotFoundError as exc:
 from model.dataset import TokenIDDataset, TokenIDSubset
 from model.trainer import Trainer
 from model.model import GPT
+from sentinel import panic
 
 
 def save_checkpoint(path, model, opt, sch, epoch):
@@ -55,12 +57,23 @@ def main():
     confpath = args.confpath
     checkpoint = args.checkpoint
 
-    confs = load_yaml(confpath)
+    try:
+        confs = load_yaml(confpath)
+    except FileNotFoundError:
+        panic(f"Config not found: {confpath}")
+    except Exception as exc:  # pragma: no cover - parse errors
+        panic(f"Failed to load config: {exc}")
 
-    train_data = TokenIDDataset(**confs['train_data'])
-    dev_data = TokenIDDataset(**confs['dev_data'])
+    try:
+        train_data = TokenIDDataset(**confs['train_data'])
+        dev_data = TokenIDDataset(**confs['dev_data'])
+    except Exception as exc:
+        panic(f"Dataset loading failed: {exc}")
 
-    model = GPT(**confs['model'])
+    try:
+        model = GPT(**confs['model'])
+    except Exception as exc:
+        panic(f"Model init failed: {exc}")
     opt = AdamW(model.get_parameters(), **confs['opt'])
     sch = OneCycleLR(opt, **confs['sch'])
     crit = CrossEntropyLoss(ignore_index=confs['unk'])
@@ -69,10 +82,13 @@ def main():
 
     start_epoch = 0
     if checkpoint is not None:
-        model.load_state_dict(load(f'{checkpoint}/model.pth'))
-        opt.load_state_dict(load(f'{checkpoint}/opt.pth'))
-        sch.load_state_dict(load(f'{checkpoint}/sch.pth'))
-        start_epoch = int(checkpoint.split('epoch_')[-1].strip('/'))
+        try:
+            model.load_state_dict(load(f'{checkpoint}/model.pth'))
+            opt.load_state_dict(load(f'{checkpoint}/opt.pth'))
+            sch.load_state_dict(load(f'{checkpoint}/sch.pth'))
+            start_epoch = int(checkpoint.split('epoch_')[-1].strip('/'))
+        except Exception as exc:
+            panic(f"Checkpoint load failed: {exc}")
 
     for epoch in range(start_epoch, confs['epochs']):
 
@@ -84,10 +100,13 @@ def main():
         tloader = DataLoader(collate_fn=collate, **confs['loader'], dataset=train)
         dloader = DataLoader(collate_fn=collate, **confs['loader'], dataset=dev)
 
-        train_metrics = trainer.run_epoch(tloader)
-        dev_metrics = trainer.run_epoch(dloader, train_mode=False)
-        publish_metrics(logger, train_metrics, dev_metrics, epoch+1)
-        save_checkpoint(confs['checkpoint'], model, opt, sch, epoch+1)
+        try:
+            train_metrics = trainer.run_epoch(tloader)
+            dev_metrics = trainer.run_epoch(dloader, train_mode=False)
+            publish_metrics(logger, train_metrics, dev_metrics, epoch+1)
+            save_checkpoint(confs['checkpoint'], model, opt, sch, epoch+1)
+        except Exception as exc:
+            panic(f"Training failed at epoch {epoch+1}: {exc}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add `sentinel.py` with `panic` helper
- harden config and model loading errors for `generate.py`
- guard configuration and dataset load errors in `train.py`
- add robust checks to preprocessing scripts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685bcb3ab4208324b2eb0ee9474712c1