### PR TITLE
Improve dataset and tokenizer error handling

### DIFF
--- a/model/dataset.py
+++ b/model/dataset.py
@@ -23,10 +23,14 @@ class TokenIDDataset(IterableDataset):
             unk: token id for unknown token
         """
         super().__init__()
+        self.datapath = datapath
         if not os.path.isfile(datapath):
             raise FileNotFoundError(f"Dataset not found: {datapath}")
-        with open(datapath, "r", encoding="utf-8") as infile:
-            self.data = infile.readlines()
+        try:
+            with open(datapath, "r", encoding="utf-8") as infile:
+                self.data = infile.readlines()
+        except OSError as exc:
+            raise RuntimeError(f"Failed to read dataset {datapath}") from exc
         self.window_size = window_size
         self.vocab_size = vocab_size
         self.unk_token = unk
@@ -41,7 +45,12 @@ class TokenIDDataset(IterableDataset):
             start = randint(0, len(line) - self.window_size - 1)
             end = start + self.window_size + 1
 
-            ids = LongTensor([int(x) for x in line[start:end]])
+            try:
+                ids = LongTensor([int(x) for x in line[start:end]])
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid token in {self.datapath} line {line_idx}: {exc}"
+                ) from exc
             ignore = (ids == self.unk_token).float()
 
             yield ids[:-1], ids[1:], ignore[:-1]

--- a/model/tokenizer.py
+++ b/model/tokenizer.py
@@ -160,27 +160,33 @@ class BytePairTokenizer:
 
     def save(self, path: str) -> None:
 
-        with open(f'{path}/freqs.json', 'w', encoding='utf-8') as outfile:
-            json.dump(self.freqs, outfile, indent=4, ensure_ascii=False)
+        try:
+            with open(f'{path}/freqs.json', 'w', encoding='utf-8') as outfile:
+                json.dump(self.freqs, outfile, indent=4, ensure_ascii=False)
 
-        with open(f'{path}/vocab_to_idx.json', 'w', encoding='utf-8') as outfile:
-            json.dump(self.vocab_to_idx, outfile, indent=4, ensure_ascii=False)
+            with open(f'{path}/vocab_to_idx.json', 'w', encoding='utf-8') as outfile:
+                json.dump(self.vocab_to_idx, outfile, indent=4, ensure_ascii=False)
 
-        with open(f'{path}/idx_to_vocab.json', 'w', encoding='utf-8') as outfile:
-            json.dump(self.idx_to_vocab, outfile, indent=4, ensure_ascii=False)
+            with open(f'{path}/idx_to_vocab.json', 'w', encoding='utf-8') as outfile:
+                json.dump(self.idx_to_vocab, outfile, indent=4, ensure_ascii=False)
+        except OSError as exc:
+            raise RuntimeError(f'Failed to save tokenizer to {path}') from exc
 
 
     @staticmethod
     def load(path: str) -> 'BytePairTokenizer':
 
-        with open(f'{path}/freqs.json', 'r', encoding='utf-8') as infile:
-            freqs = json.load(infile)
+        try:
+            with open(f'{path}/freqs.json', 'r', encoding='utf-8') as infile:
+                freqs = json.load(infile)
 
-        with open(f'{path}/vocab_to_idx.json', 'r', encoding='utf-8') as infile:
-            vocab_to_idx = json.load(infile)
+            with open(f'{path}/vocab_to_idx.json', 'r', encoding='utf-8') as infile:
+                vocab_to_idx = json.load(infile)
 
-        with open(f'{path}/idx_to_vocab.json', 'r', encoding='utf-8') as infile:
-            idx_to_vocab = json.load(infile)
+            with open(f'{path}/idx_to_vocab.json', 'r', encoding='utf-8') as infile:
+                idx_to_vocab = json.load(infile)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f'Failed to load tokenizer from {path}') from exc
 
         return BytePairTokenizer(freqs, vocab_to_idx, idx_to_vocab)
 


### PR DESCRIPTION
## Summary
- guard dataset loading against read failures
- validate tokens when iterating through dataset
- wrap tokenizer save/load with runtime checks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685bcb3ab4208324b2eb0ee9474712c1