### PR TITLE
Enhance path handling

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -14,7 +14,7 @@ except ModuleNotFoundError as exc:
 from model.tokenizer import BytePairTokenizer
 from model.sequencer import Sequencer
 from model.model import GPT
-from sentinel import panic
+from sentinel import panic, sanitize_path
 
 
 # Default configuration path. The repository stores configuration files under
@@ -31,14 +31,15 @@ def main():
     args = parser.parse_args()
     length = args.length
 
+    conf_file = sanitize_path(args.conf)
     try:
-        confs = load_yaml(args.conf)
+        confs = load_yaml(conf_file)
     except FileNotFoundError:
-        panic(f"Config not found: {args.conf}")
+        panic(f"Config not found: {conf_file}")
     except Exception as exc:  # pragma: no cover - unexpected parse errors
         panic(f"Failed to load config: {exc}")
 
-    model_path = confs.get('pretrained_model')
+    model_path = sanitize_path(confs.get('pretrained_model'))
     if not os.path.isfile(model_path):
         panic(f"Model file missing: {model_path}")
 
@@ -48,7 +49,7 @@ def main():
     except Exception as exc:
         panic(f"Could not load model: {exc}")
 
-    tok_path = confs.get('trained_tokenizer')
+    tok_path = sanitize_path(confs.get('trained_tokenizer'))
     if not os.path.isdir(tok_path):
         panic(f"Tokenizer data missing: {tok_path}")
 

--- a/model/dataset.py
+++ b/model/dataset.py
@@ -3,6 +3,8 @@
 from random import randint, sample
 import os
 
+from sentinel import sanitize_path
+
 from torch import FloatTensor, LongTensor, Tensor, stack, cat
 from torch.utils.data import IterableDataset
 from torch.nn.functional import one_hot
@@ -23,14 +25,14 @@ class TokenIDDataset(IterableDataset):
             unk: token id for unknown token
         """
         super().__init__()
-        self.datapath = datapath
-        if not os.path.isfile(datapath):
-            raise FileNotFoundError(f"Dataset not found: {datapath}")
+        self.datapath = sanitize_path(datapath)
+        if not os.path.isfile(self.datapath):
+            raise FileNotFoundError(f"Dataset not found: {self.datapath}")
         try:
-            with open(datapath, "r", encoding="utf-8") as infile:
+            with open(self.datapath, "r", encoding="utf-8") as infile:
                 self.data = infile.readlines()
         except OSError as exc:
-            raise RuntimeError(f"Failed to read dataset {datapath}") from exc
+            raise RuntimeError(f"Failed to read dataset {self.datapath}") from exc
         self.window_size = window_size
         self.vocab_size = vocab_size
         self.unk_token = unk

--- a/model/tokenizer.py
+++ b/model/tokenizer.py
@@ -3,6 +3,8 @@
 from typing import Tuple, Dict, List
 from collections import defaultdict
 import json, re
+import os
+from sentinel import sanitize_path
 
 from nltk import wordpunct_tokenize, sent_tokenize
 from tqdm import trange, tqdm
@@ -176,14 +178,15 @@ class BytePairTokenizer:
     @staticmethod
     def load(path: str) -> 'BytePairTokenizer':
 
+        path = sanitize_path(path)
         try:
-            with open(f'{path}/freqs.json', 'r', encoding='utf-8') as infile:
+            with open(os.path.join(path, 'freqs.json'), 'r', encoding='utf-8') as infile:
                 freqs = json.load(infile)
 
-            with open(f'{path}/vocab_to_idx.json', 'r', encoding='utf-8') as infile:
+            with open(os.path.join(path, 'vocab_to_idx.json'), 'r', encoding='utf-8') as infile:
                 vocab_to_idx = json.load(infile)
 
-            with open(f'{path}/idx_to_vocab.json', 'r', encoding='utf-8') as infile:
+            with open(os.path.join(path, 'idx_to_vocab.json'), 'r', encoding='utf-8') as infile:
                 idx_to_vocab = json.load(infile)
         except (OSError, json.JSONDecodeError) as exc:
             raise RuntimeError(f'Failed to load tokenizer from {path}') from exc

--- a/preprocessing/tokenize_dataset.py
+++ b/preprocessing/tokenize_dataset.py
@@ -11,7 +11,7 @@ from nltk import wordpunct_tokenize, sent_tokenize
 from tqdm import tqdm
 
 from model.tokenizer import BytePairTokenizer, count_byte_freqs
-from sentinel import panic
+from sentinel import panic, sanitize_path
 
 
 def tokenize_file(filepath: str, outdir: str, tokenizer: BytePairTokenizer,
@@ -24,9 +24,10 @@ def tokenize_file(filepath: str, outdir: str, tokenizer: BytePairTokenizer,
         tokenizer: tokenizer instance to use to tokenize file
     """
 
-    outpath = f"{outdir}/{filepath.split('/')[-1]}"
+    outpath = f"{outdir}/{os.path.basename(filepath)}"
     try:
-        lines = sent_tokenize(open(filepath, encoding='utf-8-sig').read())
+        with open(filepath, encoding='utf-8-sig') as fh:
+            lines = sent_tokenize(fh.read())
     except FileNotFoundError:
         panic(f"Input file not found: {filepath}")
 
@@ -83,13 +84,14 @@ def main():
     parser.add_argument('-j', '--jobs', required=True, type=int)
     args = parser.parse_args()
     line_length = args.line_length
-    checkpoint = args.checkpoint
-    outdir = args.outdir
-    inpath = args.inpath
+    checkpoint = sanitize_path(args.checkpoint)
+    outdir = sanitize_path(args.outdir)
+    inpath = sanitize_path(args.inpath)
     jobs = args.jobs
 
     try:
-        filepaths = [line.strip() for line in open(inpath).readlines()]
+        with open(inpath, 'r', encoding='utf-8') as infile:
+            filepaths = [line.strip() for line in infile.readlines()]
     except FileNotFoundError:
         panic(f"File list not found: {inpath}")
     try:

--- a/preprocessing/train_bpe.py
+++ b/preprocessing/train_bpe.py
@@ -5,7 +5,7 @@ import sys
 import os
 
 from model.tokenizer import BytePairTokenizer
-from sentinel import panic
+from sentinel import panic, sanitize_path
 
 
 def main():
@@ -17,13 +17,14 @@ def main():
     parser.add_argument('-m', '--merges', required=True, type=int)
     parser.add_argument('-n', '--mincount', required=True, type=int)
     args = parser.parse_args()
-    outpath = args.outpath
-    inpath = args.inpath
+    outpath = sanitize_path(args.outpath)
+    inpath = sanitize_path(args.inpath)
     merges = args.merges
     mincount = args.mincount
 
     try:
-        filepaths = [path.strip() for path in open(inpath).readlines()]
+        with open(inpath, 'r', encoding='utf-8') as infile:
+            filepaths = [path.strip() for path in infile.readlines()]
     except FileNotFoundError:
         panic(f"File list not found: {inpath}")
     try:

--- a/sentinel.py
+++ b/sentinel.py
@@ -1,9 +1,19 @@
 """Sentinel helpers for graceful failure."""
 
 import sys
+from pathlib import Path
 
 
 def panic(message: str) -> None:
     """Print error with emoji and exit."""
     print(f"\N{bomb} {message}", file=sys.stderr)
     raise SystemExit(1)
+
+
+def sanitize_path(path: str) -> str:
+    """Resolve ``path`` safely or terminate on failure."""
+    try:
+        safe_path = Path(path).expanduser().resolve()
+    except Exception as exc:  # pragma: no cover - extremely rare failures
+        panic(f"Invalid path: {exc}")
+    return str(safe_path)

--- a/train.py
+++ b/train.py
@@ -20,11 +20,12 @@ except ModuleNotFoundError as exc:
 from model.dataset import TokenIDDataset, TokenIDSubset
 from model.trainer import Trainer
 from model.model import GPT
-from sentinel import panic
+from sentinel import panic, sanitize_path
 
 
 def save_checkpoint(path, model, opt, sch, epoch):
 
+    path = sanitize_path(path)
     filepath = f'{path}/epoch_{epoch}'
     if os.path.exists(filepath):
         shutil.rmtree(filepath)
@@ -54,8 +55,8 @@ def main():
     parser.add_argument('-c', '--confpath', type=str, required=True)
     parser.add_argument('-ch', '--checkpoint', type=str, default=None)
     args = parser.parse_args()
-    confpath = args.confpath
-    checkpoint = args.checkpoint
+    confpath = sanitize_path(args.confpath)
+    checkpoint = sanitize_path(args.checkpoint) if args.checkpoint else None
 
     try:
         confs = load_yaml(confpath)


### PR DESCRIPTION
## Summary
- add `sanitize_path` helper in `sentinel`
- use sanitized paths and context managers throughout data processing scripts
- tighten tokenizer loading with path checks
- secure dataset loader and training flow

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685bcb3ab4208324b2eb0ee9474712c1