### PR TITLE
Improve parser security

### DIFF
--- a/transformer/services/config.py
+++ b/transformer/services/config.py
@@ -27,6 +27,8 @@ def load_config(config_path=None, env_prefix=None, defaults=None):
                     config[key.upper()] = val
         except FileNotFoundError:
             pass
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON in config file {config_path}") from exc
     # Override with environment variables
     for key, val in os.environ.items():
         # Apply prefix filter if given

--- a/transformer/services/dialogue.py
+++ b/transformer/services/dialogue.py
@@ -2,6 +2,7 @@
 
 import re
 import random
+import string
 
 # Reflection map for pronoun swapping
 reflections = {
@@ -98,6 +99,17 @@ doctor_patterns = [
 # Use the same patterns for ELIZA persona (alias to doctor_patterns)
 eliza_patterns = doctor_patterns
 
+
+def sanitize_input(text: str, limit: int = 500) -> str:
+    """Remove non-printable characters and trim to a sane length."""
+    if not isinstance(text, str):
+        raise TypeError("message must be a string")
+    cleaned = "".join(ch for ch in text if ch in string.printable)
+    cleaned = cleaned.strip()
+    if len(cleaned) > limit:
+        cleaned = cleaned[:limit]
+    return cleaned
+
 def reflect(fragment):
     """Reflects a fragment of input by swapping pronouns (I -> you, me -> you, etc.)."""
     tokens = fragment.lower().split()
@@ -108,6 +120,7 @@ def reflect(fragment):
 
 def generate_response(message, persona="doctor"):
     """Generate a response to the user's message using the specified persona's rules."""
+    message = sanitize_input(message)
     patterns = doctor_patterns if persona == "doctor" else eliza_patterns
     for pattern, responses in patterns:
         match = re.match(pattern, message.strip(), re.IGNORECASE)


### PR DESCRIPTION
## Summary
- sanitize incoming dialogue before matching patterns
- error on invalid JSON config

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685bcb3ab4208324b2eb0ee9474712c1