### PR TITLE
Improve tokenizer and dataset robustness

### DIFF
--- a/model/dataset.py
+++ b/model/dataset.py
@@ -46,11 +46,19 @@ class TokenIDDataset(IterableDataset):
             end = start + self.window_size + 1
 
             try:
-                ids = LongTensor([int(x) for x in line[start:end]])
+                int_ids = [int(x) for x in line[start:end]]
             except ValueError as exc:
                 raise ValueError(
                     f"Invalid token in {self.datapath} line {line_idx}: {exc}"
                 ) from exc
+
+            for tid in int_ids:
+                if tid < 0 or tid >= self.vocab_size:
+                    raise ValueError(
+                        f"Token ID {tid} out of range in {self.datapath} line {line_idx}"
+                    )
+
+            ids = LongTensor(int_ids)
             ignore = (ids == self.unk_token).float()
 
             yield ids[:-1], ids[1:], ignore[:-1]

--- a/model/tokenizer.py
+++ b/model/tokenizer.py
@@ -176,6 +176,11 @@ class BytePairTokenizer:
     @staticmethod
     def load(path: str) -> 'BytePairTokenizer':
 
+        required = ['freqs.json', 'vocab_to_idx.json', 'idx_to_vocab.json']
+        for fname in required:
+            if not os.path.isfile(f'{path}/{fname}'):
+                raise FileNotFoundError(f'Missing {fname} in {path}')
+
         try:
             with open(f'{path}/freqs.json', 'r', encoding='utf-8') as infile:
                 freqs = json.load(infile)
@@ -193,7 +198,7 @@ class BytePairTokenizer:
 
     @staticmethod
     def train_bpe(filepaths: List[str], mincount: int, merges: int) \
-                  -> 'BytePairtokenizer':
+                  -> 'BytePairTokenizer':
         """ Create trained byte pair tokenizer
 
         Args:
@@ -235,7 +240,12 @@ def create_vocab(filepaths: List[str]) -> Dict[str, int]:
 
     vocab = defaultdict(int)
     for path in tqdm(filepaths, desc='Creating vocabulary'):
-        text = open(path, 'r', encoding='utf-8-sig').read()
+        try:
+            with open(path, 'r', encoding='utf-8-sig') as fh:
+                text = fh.read()
+        except OSError as exc:
+            raise RuntimeError(f'Failed to read {path}') from exc
+
         sentences = sent_tokenize(text)
 
         for sentence in sentences:


### PR DESCRIPTION
## Summary
- add token ID range validation in `TokenIDDataset`
- tighten file checking logic in `BytePairTokenizer.load`
- handle I/O errors when creating BPE vocabulary
- fix return type hint for `train_bpe`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685bcb3ab4208324b2eb0ee9474712c1