### PR TITLE
Fix tokenizer load bug

### DIFF
--- a/model/tokenizer.py
+++ b/model/tokenizer.py
@@ -213,6 +213,8 @@ class BytePairTokenizer:
             encoding='utf-8',
         ) as infile:
             idx_to_vocab = json.load(infile)
+            # json converts dictionary keys to strings; convert back to ints
+            idx_to_vocab = {int(k): v for k, v in idx_to_vocab.items()}
 
         return BytePairTokenizer(freqs, vocab_to_idx, idx_to_vocab)
 

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -34,3 +34,22 @@ def test_merge_vocab():
     assert 'ab' in merged
     assert merged['ab'] == 2
     assert 'a b' not in merged
+
+
+def test_save_load_roundtrip(tmp_path):
+    freqs = {
+        'a': 1,
+        '<unk>': 1,
+        '<pad>': 1,
+        '<line/>': 1,
+        '</line>': 1,
+        '</w>': 1,
+    }
+    v2i, i2v = create_vocab_maps(freqs)
+    tokenizer = BytePairTokenizer(freqs, v2i, i2v)
+    tokenizer.save(tmp_path)
+    loaded = BytePairTokenizer.load(tmp_path)
+    assert loaded.vocab_to_idx == tokenizer.vocab_to_idx
+    assert loaded.idx_to_vocab == tokenizer.idx_to_vocab
+    # ensure integer keys were preserved
+    assert isinstance(next(iter(loaded.idx_to_vocab.keys())), int)


### PR DESCRIPTION
## Summary
- fix `BytePairTokenizer.load` so JSON keys are converted back to ints
- add a regression test for tokenizer save/load roundtrip

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685bff4f2e3c832494e03bf8dea1239e