### PR TITLE
Fix sequencer token bug

### DIFF
--- a/model/sequencer.py
+++ b/model/sequencer.py
@@ -54,7 +54,7 @@ class Sequencer:
             for i in trange(length):
                 probs, _ = self.model(token_ids, ignore_ids)
                 next_id = self.gen_next_token(probs, idx)
-                tokens.append(self.tokenizer.get_byte(str(next_id.item())))
+                tokens.append(self.tokenizer.get_byte(next_id.item()))
                 token_ids, ignore_ids, idx = self.update_token_ids(
                     idx, token_ids, next_id
                 )

--- a/model/tokenizer.py
+++ b/model/tokenizer.py
@@ -221,7 +221,7 @@ class BytePairTokenizer:
 
     @staticmethod
     def train_bpe(filepaths: List[str], mincount: int, merges: int) \
-                  -> 'BytePairtokenizer':
+                  -> 'BytePairTokenizer':
         """ Create trained byte pair tokenizer
 
         Args:


### PR DESCRIPTION
## Summary
- fix generation bug by passing int id to `get_byte`
- fix a typo in a return type annotation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e1106c86c8324b67c6dc8244463d8