### PR TITLE
Fix type annotation in tokenizer

### DIFF
--- a/model/tokenizer.py
+++ b/model/tokenizer.py
@@ -221,7 +221,7 @@ class BytePairTokenizer:
 
     @staticmethod
     def train_bpe(filepaths: List[str], mincount: int, merges: int) \
-                  -> 'BytePairtokenizer':
+                  -> 'BytePairTokenizer':
         """ Create trained byte pair tokenizer
 
         Args:


### PR DESCRIPTION
## Summary
- fix typo in `BytePairTokenizer.train_bpe` return annotation

## Testing
- `pytest -q`
- `python -m pip install --upgrade pip` *(fails: Tunnel connection failed)*
- `pip install pytest`
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_685e1106c86c8324b67c6dc8244463d8