### PR TITLE
Fix dataset bug and tokenizer type hint

### DIFF
--- a/model/dataset.py
+++ b/model/dataset.py
@@ -31,12 +31,16 @@ class TokenIDDataset(IterableDataset):
     def __iter__(self):
         for line_idx in range(len(self.data)):
 
-            line = self.data[line_idx].strip().split(' ')
-            start = randint(0, len(line)-self.window_size-1)
+            line_tokens = self.data[line_idx].strip().split(' ')
+
+            if len(line_tokens) <= self.window_size:
+                continue
+
+            start = randint(0, len(line_tokens) - self.window_size - 1)
             end = start + self.window_size + 1
 
-            ids = LongTensor([int(x) for x in line[start:end]])
-            ignore = (ids==self.unk_token).float()
+            ids = LongTensor([int(x) for x in line_tokens[start:end]])
+            ignore = (ids == self.unk_token).float()
 
             yield ids[:-1], ids[1:], ignore[:-1]
 

--- a/model/tokenizer.py
+++ b/model/tokenizer.py
@@ -220,8 +220,11 @@ class BytePairTokenizer:
 
 
     @staticmethod
-    def train_bpe(filepaths: List[str], mincount: int, merges: int) \
-                  -> 'BytePairtokenizer':
+    def train_bpe(
+        filepaths: List[str],
+        mincount: int,
+        merges: int,
+    ) -> 'BytePairTokenizer':
         """ Create trained byte pair tokenizer
 
         Args:


### PR DESCRIPTION
## Summary
- fix negative index bug in `TokenIDDataset.__iter__`
- correct return type annotation for `BytePairTokenizer.train_bpe`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e1106c86c8324b67c6dc8244463d8