### PR TITLE
Fix trainer output handling

### DIFF
--- a/model/trainer.py
+++ b/model/trainer.py
@@ -90,8 +90,9 @@ class Trainer:
             self.model.zero_grad()
             self.opt.zero_grad()
 
-        y_pred = self.model(x, ignore)
-        y_pred = y_pred.view(-1, y_pred.size(-1))
+        # ``self.model`` returns a tuple ``(logits, hidden_states)``.
+        logits, _ = self.model(x, ignore)
+        y_pred = logits.view(-1, logits.size(-1))
         y = y.view(-1)
         loss = self.crit(y_pred, y)
 


### PR DESCRIPTION
## Summary
- unpack the GPT model output in the trainer

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e1102248c8324bf900ece63db0d0f