### PR TITLE
Fix tokenizer loading keys and sequencer bug

### DIFF
--- a/model/sequencer.py
+++ b/model/sequencer.py
@@ -50,7 +50,7 @@ class Sequencer:
                 # Only the logits are required for probability calculation.
                 logits, _ = self.model(token_ids, ignore_ids)
                 next_id = self.gen_next_token(logits, idx)
-                tokens.append(self.tokenizer.get_byte(str(next_id.item())))
+                tokens.append(self.tokenizer.get_byte(next_id.item()))
                 token_ids, ignore_ids, idx = self.update_token_ids(
                     idx, token_ids, next_id
                 )

--- a/model/tokenizer.py
+++ b/model/tokenizer.py
@@ -192,7 +192,7 @@ class BytePairTokenizer:
                 vocab_to_idx = json.load(infile)
 
             with open(os.path.join(path, 'idx_to_vocab.json'), 'r', encoding='utf-8') as infile:
-                idx_to_vocab = json.load(infile)
+                idx_to_vocab = {int(k): v for k, v in json.load(infile).items()}
         except (OSError, json.JSONDecodeError) as exc:
             raise RuntimeError(f'Failed to load tokenizer from {path}') from exc
 


### PR DESCRIPTION
## Summary
- convert `idx_to_vocab` keys to integers when loading tokenizer
- fetch correct token by ID in the sequencer

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e1102248c8324bf900ece63db0d0f