### PR TITLE
Fix dataset line splitting bug

### DIFF
--- a/model/dataset.py
+++ b/model/dataset.py
@@ -31,7 +31,7 @@ class TokenIDDataset(IterableDataset):
     def __iter__(self):
         for line_idx in range(len(self.data)):
 
-            line_tokens = self.data[line_idx].strip().split(' ')
+            line_tokens = self.data[line_idx].split()
 
             if len(line_tokens) <= self.window_size:
                 continue


### PR DESCRIPTION
## Summary
- avoid ValueError when spaces are doubled in token id datasets
- update dataset line parsing logic to use generic whitespace split

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e526131e0832484f5a7a517bf0078