### PR TITLE
Fix alias resolution in minimal YAML loader

### DIFF
--- a/minimal_yaml.py
+++ b/minimal_yaml.py
@@ -20,7 +20,9 @@ def safe_load(stream):
             line = f"{indent}{key}: {val}"
         elif alias_def:
             indent, key, anc = alias_def.groups()
-            val = anchors.get(anc)
+            if anc not in anchors:
+                raise ValueError(f'Alias "{anc}" not defined')
+            val = anchors[anc]
             val_repr = repr(val) if isinstance(val, str) else str(val)
             line = f"{indent}{key}: {val_repr}"
         processed.append(line)

--- a/tests/test_minimal_yaml.py
+++ b/tests/test_minimal_yaml.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from minimal_yaml import safe_load
+
+
+def test_alias_resolution():
+    text = """
+key1: &val 123
+key2: *val
+"""
+    data = safe_load(text)
+    assert data["key1"] == 123
+    assert data["key2"] == 123
+
+
+def test_unknown_alias_error():
+    text = "key: *missing"
+    with pytest.raises(ValueError):
+        safe_load(text)


### PR DESCRIPTION
## Summary
- improve `minimal_yaml.safe_load` to raise an error for undefined aliases
- add tests ensuring alias handling works and errors are raised

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e526131e0832484f5a7a517bf0078