### PR TITLE
PEP8 cleanup, sequencer & trainer refactor, and test hardening

### DIFF
--- a/model/dataset.py
+++ b/model/dataset.py
@@ -1,8 +1,7 @@
 from random import randint, sample
 
-from torch import FloatTensor, LongTensor, Tensor, stack, cat
+from torch import LongTensor, Tensor, cat
 from torch.utils.data import IterableDataset
-from torch.nn.functional import one_hot
 
 """Dataset utilities for handling token ID sequences."""
 

--- a/model/model.py
+++ b/model/model.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 import torch
 from torch.nn import ModuleList, Embedding, LayerNorm, Dropout, Softmax, \
                      Linear, Module, GELU
-from torch import LongTensor, Tensor, einsum, ones, sqrt, tril, triu, cat
+from torch import Tensor, einsum, sqrt, cat
 from torch.nn.init import normal_, ones_, zeros_
 
 class GPT(Module):

--- a/model/model_Q.py
+++ b/model/model_Q.py
@@ -1,11 +1,9 @@
+"""Alternative GPT implementation with experimental decoding methods."""
+
 import random
 
 import torch
 import torch.nn as nn
-from config import *
-
-"""Alternative GPT implementation with experimental decoding methods."""
-import copy
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -156,7 +154,7 @@ class Decoder(nn.Module):
     def __init__(self, arg, vob_len):
         super().__init__()
         self.arg = arg
-        self.embedding = EmbeddingLayer(self.arg,vob_len)
+        self.embedding = EmbeddingLayer(self.arg, vob_len)
         # self.layers = nn.Sequential(*[DecoderBlock() for i in range(3)])
         self.layers = nn.ModuleList([
             DecoderBlock(self.arg)

--- a/model/sequencer.py
+++ b/model/sequencer.py
@@ -1,57 +1,43 @@
-from typing import List
-
-from torch import LongTensor, multinomial, Tensor, no_grad, argsort, full, cat
-from torch.nn.functional import softmax
-from torch import long as long_
-
 """Sequence generation utilities for autoregressive decoding."""
+
+from typing import Any
+
+from torch import LongTensor, Tensor, argsort, cat, full, multinomial, no_grad
+from torch import long as long_
+from torch.nn.functional import softmax
 from tqdm import trange
 
 
 class Sequencer:
-
+    """Helper class that performs top-k autoregressive text generation."""
 
     def __init__(
         self,
-        model: 'Model',
-        tokenizer: 'Tokenizer',
+        model: Any,
+        tokenizer: Any,
         window_size: int,
         k: int,
         device: str,
     ):
-        """ Initialize sequencer
-
-        Args:
-            model: model used for generating sequence
-            tokenizer: tokenizer for encoding / decoding ids and tokens
-            window_size: window size for sequence generation
-            k: k value for top-k decoding
-            device: device to load sequencer on
-        """
+        """Initialize sequence generator state."""
+        # Dev Agent Breadcrumb: initialize dependencies used by all generation
+        # steps to keep data flow explicit across helper methods.
         self.window_size = window_size
         self.tokenizer = tokenizer
         self.device = device
         self.model = model
         self.k = k
 
-
-    def generate_sequence(self, length: int, start: str=None) -> str:
-        """ Generate text sequence with starting input if provided
-
-        Args:
-            length: length of sequence to generate (in bytes)
-            start: input sequence to start with (not necessary)
-
-        Return:
-            (str): generated sequence string
-        """
-
+    def generate_sequence(self, length: int, start: str | None = None) -> str:
+        """Generate a text sequence with optional prompt text."""
+        # Dev Agent Breadcrumb: bootstrap token state from prompt, then iterate
+        # one token at a time using model probabilities and top-k sampling.
         tokens, token_ids, ignore_ids = self.generate_start_seq(start)
         idx = len(tokens) - 1
 
         self.model.eval()
         with no_grad():
-            for i in trange(length):
+            for _ in trange(length):
                 probs, _ = self.model(token_ids, ignore_ids)
                 next_id = self.gen_next_token(probs, idx)
                 tokens.append(self.tokenizer.get_byte(next_id.item()))
@@ -61,134 +47,74 @@ class Sequencer:
 
         return self.generate_text(tokens)
 
-
     def generate_start_seq(
         self,
         start: str | None = None,
     ) -> tuple[list[str], Tensor, Tensor]:
-        """ Generate initial starting sequence of tokens, token ids, and ids to
-            ignore (padding / unknowns etc)
-
-        Args:
-            start: string sequence to start with
-
-        Returns:
-            (List[str]): List of tokens
-            (Tensor): Tensor of byte token ids
-            (Tensor): Tensor of flags indicating ides to ignore
-        """
-
+        """Create initial token/string/id tensors used by generation."""
         pad_id = self.tokenizer.get_byte_id(self.tokenizer.get_pad())
         tokens = [self.tokenizer.get_sol()]
 
         if start:
-            chunks = start.split(" ")
-            for chunk in chunks:
+            for chunk in start.split(" "):
                 bytes_ = list(chunk) + [self.tokenizer.get_eow()]
                 tokens += self.tokenizer.merge_bytes(bytes_)
 
-        token_ids = LongTensor(
-            self.tokenizer.get_byte_ids(tokens)
-        ).unsqueeze(0)
+        token_ids = LongTensor(self.tokenizer.get_byte_ids(tokens)).unsqueeze(0)
         token_ids = token_ids.to(device=self.device)
         token_ids = self.pad_token_ids(token_ids, pad_id)
-        ignore_ids = (token_ids==pad_id).float().to(device=self.device) 
+        ignore_ids = (token_ids == pad_id).float().to(device=self.device)
         return tokens, token_ids, ignore_ids
 
-
-    def update_token_ids(self, idx: int, token_ids: Tensor, next_id: Tensor) \
-                        -> (Tensor, Tensor, int):
-        """ Update current sequence of tensor ids
-
-        Args:
-            idx: index last generated token
-            token_ids: tensor of current token ids
-            next_id: next token id to add to token ids tensor
-
-        Returns:
-            (Tensor): tensor of token ids
-            (Tensor): tensor of flag with token ids to ignore
-            (int): new index
-        """
-
+    def update_token_ids(
+        self,
+        idx: int,
+        token_ids: Tensor,
+        next_id: Tensor,
+    ) -> tuple[Tensor, Tensor, int]:
+        """Update sequence tensor by appending/rolling to fixed window size."""
         pad_id = self.tokenizer.get_byte_id(self.tokenizer.get_pad())
-        if idx < self.window_size-1:
-            token_ids = cat(
-                [token_ids[:, : idx + 1], next_id.unsqueeze(0)],
-                dim=1,
-            )
+        if idx < self.window_size - 1:
+            token_ids = cat([token_ids[:, : idx + 1], next_id.unsqueeze(0)], dim=1)
             token_ids = self.pad_token_ids(token_ids, pad_id)
-            ignore_ids = (token_ids==pad_id).float() 
+            ignore_ids = (token_ids == pad_id).float()
             idx += 1
-
         else:
             token_ids = cat([token_ids[:, 1:], next_id.unsqueeze(0)], dim=1)
-            ignore_ids = (token_ids==pad_id).float() 
+            ignore_ids = (token_ids == pad_id).float()
 
         return token_ids, ignore_ids, idx
 
-
     def gen_next_token(self, probs: Tensor, idx: int) -> Tensor:
-        """ Get next token id given token probabilities
-
-        Args:
-            probs: tensor of probabilities for each vocabulary term
-            idx: index of last generated token id
-
-        Returns:
-            (Tensor): new token id
-        """
-
+        """Sample the next token from the model's top-k logits."""
         next_id_probs = probs[:, idx, :].flatten()
-        next_id_cands = argsort(next_id_probs, descending=True)[:self.k]
+        next_id_cands = argsort(next_id_probs, descending=True)[: self.k]
         next_id_probs = next_id_probs[next_id_cands]
         next_id_probs = softmax(next_id_probs, dim=0)
         return next_id_cands[multinomial(next_id_probs, 1)]
 
-
     def pad_token_ids(self, token_ids: Tensor, pad_id: int) -> Tensor:
-        """ Pad token ids if less than required window size
-
-        Args:
-            token_ids: tensor of token ids to pad
-            pad_id: id of token to pad input with
-
-        Returns:
-            (Tensor): padded tensor of token ids
-        """
-
+        """Pad or trim IDs so the tensor always matches ``window_size``."""
         pad_size = self.window_size - token_ids.size(1)
         if pad_size > 0:
             padding = full((1, pad_size), pad_id, dtype=long_, device=self.device)
             token_ids = cat([token_ids, padding], dim=1)
         elif pad_size < 0:
-            token_ids = token_ids[:, -self.window_size:]
+            token_ids = token_ids[:, -self.window_size :]
         return token_ids
 
-
-    def generate_text(self, tokens: List[str]) -> str:
-        """ Turn list of tokens into output text
-
-        Args:
-            tokens: list of tokens to turn into output text
-
-        Returns:
-            (str)
-        """
-
-        text, word = [], ''
-        for i in range(len(tokens)):
-
-            word += tokens[i]
-            if word.startswith('<line/>'):
+    def generate_text(self, tokens: list[str]) -> str:
+        """Convert a list of tokenizer bytes into human-readable text."""
+        text, word = [], ""
+        for token in tokens:
+            word += token
+            if word.startswith("<line/>"):
                 word = word[7:]
-
-            elif word.endswith('</line>'):
+            elif word.endswith("</line>"):
                 word = word[:-7]
 
-            if word.endswith('</w>'):
+            if word.endswith("</w>"):
                 text.append(word[:-4])
-                word = ''
+                word = ""
 
-        return ' '.join(text)
-
+        return " ".join(text)

--- a/model/tokenizer.py
+++ b/model/tokenizer.py
@@ -1,6 +1,7 @@
 from typing import Tuple, Dict, List
 from collections import defaultdict
-import json, re
+import json
+import re
 
 try:
     from nltk import wordpunct_tokenize, sent_tokenize

--- a/model/trainer.py
+++ b/model/trainer.py
@@ -1,54 +1,43 @@
-from typing import Dict
+"""Training utilities for running epochs and optimization."""
 
-from torch import set_grad_enabled, argmax, Tensor
+from typing import Any
+
+from torch import Tensor, argmax, set_grad_enabled
 from torch.nn.utils import clip_grad_norm_
 from torch.utils.data import DataLoader
-
-"""Training utilities for running epochs and optimization."""
 from tqdm import tqdm
 
 from model.utils import RollingCounter
 
 
 class Trainer:
+    """Encapsulate training/evaluation logic for one model."""
 
-
-    def __init__(self, model: 'Model', crit: 'Loss', opt: 'Optimizer', 
-                 sch: 'Scheduler', device: str):
-        """ Initialize trainer
-
-        Args:
-            model: model to train
-            crit: loss function to train with
-            opt: optimizer to train with
-            sch: learning rate scheduler
-            device: device to place trainer on
-        """
-
+    def __init__(
+        self,
+        model: Any,
+        crit: Any,
+        opt: Any,
+        sch: Any,
+        device: str,
+    ):
+        """Initialize trainer dependencies and runtime device."""
         self.device = device
         self.model = model
         self.crit = crit
         self.opt = opt
         self.sch = sch
-        
 
     def run_epoch(
         self,
         loader: DataLoader,
         train_mode: bool = True,
-    ) -> Dict[str, int]:
-        """ Run a single epoch of training
-
-        Args:
-            loader: data loader to train / evaluate data on
-            train_mode: flag indicating whether epoch is training or evaluation
-
-        Returns:
-            (Dict[str, int]): dictionary containing epoch metrics
-        """
-
+    ) -> dict[str, float]:
+        """Run a single training or evaluation epoch and return metrics."""
+        # Dev Agent Breadcrumb: each batch executes `step`, then metrics are
+        # aggregated in a rolling counter for both progress and final summary.
         loss_metric, err_metric = RollingCounter(1000), RollingCounter(1000)
-        progress = tqdm(total=len(loader), desc='LR: | Loss: | Err: ')
+        progress = tqdm(total=len(loader), desc="LR: | Loss: | Err: ")
 
         self.model.train(mode=train_mode)
         with set_grad_enabled(train_mode):
@@ -61,35 +50,27 @@ class Trainer:
                 err_metric.add(err)
 
                 progress.set_description(
-                    f'LR: {self.sch.get_last_lr()[-1]:.8f} | '
-                    f'Loss: {loss_metric.rolling_average():.8f} | '
-                    f'Err: {err_metric.rolling_average():.8f}'
+                    f"LR: {self.sch.get_last_lr()[-1]:.8f} | "
+                    f"Loss: {loss_metric.rolling_average():.8f} | "
+                    f"Err: {err_metric.rolling_average():.8f}"
                 )
                 progress.update(1)
 
         return {
-            'total_average_loss': loss_metric.total_average(),
-            'rolling_average_loss': loss_metric.rolling_average(),
-            'total_average_err': err_metric.total_average(),
-            'rolling_average_err': err_metric.rolling_average(),
+            "total_average_loss": loss_metric.total_average(),
+            "rolling_average_loss": loss_metric.rolling_average(),
+            "total_average_err": err_metric.total_average(),
+            "rolling_average_err": err_metric.rolling_average(),
         }
 
-
-    def step(self, x: Tensor, y: Tensor, ignore: Tensor, 
-             train_mode: bool=True) -> (float, float):
-        """ Run one training step
-
-        Args:
-            x: input
-            y: labels
-            ignore: input indices to ignore
-            train_mode: flag indicating whether to train model during step
-
-        Returns:
-            (float): loss
-            (float): error
-        """
-
+    def step(
+        self,
+        x: Tensor,
+        y: Tensor,
+        ignore: Tensor,
+        train_mode: bool = True,
+    ) -> tuple[float, float]:
+        """Run one forward/backward/optimization step and return loss+error."""
         if train_mode:
             self.model.zero_grad()
             self.opt.zero_grad()
@@ -106,7 +87,6 @@ class Trainer:
             self.sch.step()
 
         y_pred = argmax(y_pred, dim=1)
-        err = (y_pred!=y).sum() / y.shape[0]
+        err = (y_pred != y).sum() / y.shape[0]
 
         return loss.item(), err
-

--- a/preprocessing/tokenize_dataset.py
+++ b/preprocessing/tokenize_dataset.py
@@ -6,7 +6,7 @@ from typing import List
 from nltk import wordpunct_tokenize, sent_tokenize
 from tqdm import tqdm
 
-from model.tokenizer import BytePairTokenizer, count_byte_freqs
+from model.tokenizer import BytePairTokenizer
 
 """Utilities for tokenizing raw text files into ID sequences."""
 

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -1,67 +1,96 @@
+import importlib
 import os
 import sys
 import types
 
-sys.modules['torch'] = types.SimpleNamespace(
-    LongTensor=object,
-    multinomial=lambda *a, **k: None,
-    Tensor=object,
-    no_grad=lambda: type('C', (), {'__enter__': lambda self: None, '__exit__': lambda self, exc_type, exc, tb: None})(),
-    argsort=lambda x, descending=False: x,
-    full=lambda *a, **k: None,
-    cat=lambda *a, **k: None,
-    long=int,
-)
-sys.modules['torch.nn.functional'] = types.SimpleNamespace(softmax=lambda x, dim=None: x)
-sys.modules['tqdm'] = types.SimpleNamespace(trange=lambda *a, **k: range(a[0] if a else 0))
-
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from model.sequencer import Sequencer
 
 class DummyTokenizer:
     def get_sol(self):
         return '<line/>'
+
     def get_eol(self):
         return '</line>'
+
     def get_pad(self):
         return '<pad>'
+
     def get_eow(self):
         return '</w>'
+
     def merge_bytes(self, bytes_):
         return bytes_
+
     def get_byte_ids(self, tokens):
         return [0]
+
     def get_byte_id(self, b):
         return 0
+
     def __init__(self):
         self.last_byte_arg = None
+
     def get_byte(self, idx):
-        # record argument type
         self.last_byte_arg = type(idx)
         return 'x'
 
+
 class DummyModel:
     def eval(self):
-        pass
+        return None
+
     def __call__(self, token_ids, ignore_ids):
         return None, None
+
 
 class FakeTensor:
     def __init__(self, v):
         self.v = v
+
     def item(self):
         return self.v
 
 
-def test_generate_sequence_passes_int_id():
+def test_generate_sequence_passes_int_id(monkeypatch):
+    fake_torch = types.SimpleNamespace(
+        LongTensor=object,
+        multinomial=lambda *a, **k: None,
+        Tensor=object,
+        no_grad=lambda: type(
+            'C',
+            (),
+            {
+                '__enter__': lambda self: None,
+                '__exit__': lambda self, exc_type, exc, tb: None,
+            },
+        )(),
+        argsort=lambda x, descending=False: x,
+        full=lambda *a, **k: None,
+        cat=lambda *a, **k: None,
+        long=int,
+    )
+    monkeypatch.setitem(sys.modules, 'torch', fake_torch)
+    monkeypatch.setitem(
+        sys.modules,
+        'torch.nn.functional',
+        types.SimpleNamespace(softmax=lambda x, dim=None: x),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        'tqdm',
+        types.SimpleNamespace(trange=lambda *a, **k: range(a[0] if a else 0)),
+    )
+
+    sequencer_module = importlib.import_module('model.sequencer')
+    Sequencer = sequencer_module.Sequencer
+
     tokenizer = DummyTokenizer()
     seq = Sequencer(DummyModel(), tokenizer, window_size=1, k=1, device='cpu')
 
-    # Patch methods that rely on torch functionality
     seq.generate_start_seq = lambda start=None: (['<line/>'], [0], [0])
     seq.gen_next_token = lambda probs, idx: FakeTensor(0)
-    seq.update_token_ids = lambda idx, token_ids, next_id: (token_ids, token_ids, idx+1)
+    seq.update_token_ids = lambda idx, token_ids, next_id: (token_ids, token_ids, idx + 1)
 
     seq.generate_sequence(length=1)
 

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,14 +1,24 @@
+import importlib
 import os
 import sys
 import types
 
-sys.modules["tqdm"] = types.SimpleNamespace(trange=lambda *a, **k: range(a[0] if a else 0), tqdm=lambda x, **k: x)
-sys.modules["nltk"] = types.SimpleNamespace(wordpunct_tokenize=lambda t: [], sent_tokenize=lambda t: [])
+sys.modules['tqdm'] = types.SimpleNamespace(
+    trange=lambda *a, **k: range(a[0] if a else 0),
+    tqdm=lambda x, **k: x,
+)
+sys.modules['nltk'] = types.SimpleNamespace(
+    wordpunct_tokenize=lambda t: [],
+    sent_tokenize=lambda t: [],
+)
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-import pytest
 
-from model.tokenizer import create_vocab_maps, BytePairTokenizer, merge_vocab
+
+tokenizer_module = importlib.import_module("model.tokenizer")
+BytePairTokenizer = tokenizer_module.BytePairTokenizer
+create_vocab_maps = tokenizer_module.create_vocab_maps
+merge_vocab = tokenizer_module.merge_vocab
 
 
 def test_create_vocab_maps_ordering():
@@ -21,7 +31,14 @@ def test_create_vocab_maps_ordering():
 
 
 def test_get_byte_id_unknown():
-    freqs = {'a': 1, '<unk>': 1, '<pad>': 1, '<line/>': 1, '</line>': 1, '</w>': 1}
+    freqs = {
+        'a': 1,
+        '<unk>': 1,
+        '<pad>': 1,
+        '<line/>': 1,
+        '</line>': 1,
+        '</w>': 1,
+    }
     v2i, i2v = create_vocab_maps(freqs)
     tokenizer = BytePairTokenizer(freqs, v2i, i2v)
     unk_id = v2i['<unk>']
@@ -57,5 +74,4 @@ def test_save_load_roundtrip(tmp_path):
     loaded = BytePairTokenizer.load(tmp_path)
     assert loaded.vocab_to_idx == tokenizer.vocab_to_idx
     assert loaded.idx_to_vocab == tokenizer.idx_to_vocab
-    # ensure integer keys were preserved
     assert isinstance(next(iter(loaded.idx_to_vocab.keys())), int)


### PR DESCRIPTION
### Motivation
- Improve code style and readability across core modules to meet PEP8/ruff expectations and make runtime logic easier to follow.  
- Make sequence generation and training flow explicit with developer-facing breadcrumbs so the logic flow is easier to trace and maintain.  
- Harden lightweight unit tests so they do not trigger import-order or environment-dependent lint issues.  

### Description
- Removed unused imports, split combined imports, and eliminated wildcard imports in several modules to fix ruff warnings and improve import ordering (`model/dataset.py`, `model/model.py`, `model/model_Q.py`, `model/tokenizer.py`).  
- Refactored `model/sequencer.py` to use explicit `Any` typing, clearer return types, and added Dev Agent Breadcrumb comments describing the generation bootstrap and iterative sampling flow.  
- Refactored `model/trainer.py` for clearer typing, tightened function signatures, added a breadcrumb describing per-batch metric aggregation, and standardized progress formatting.  
- Adjusted `model/model_Q.py` formatting and removed a wildcard import to reduce lint noise and improve module-level import layout.  
- Updated preprocessing and tokenizer usages to avoid unused imports (`preprocessing/tokenize_dataset.py`) and added small readability fixes in `model/tokenizer.py`.  
- Hardened tests (`tests/test_sequencer.py`, `tests/test_tokenizer.py`) by mocking environment dependencies and switching to dynamic imports/monkeypatch where needed to avoid import-order/side-effect issues while preserving assertions.  

### Testing
- Ran style checks with `ruff check .` which reports no remaining issues after the changes (passed).  
- Executed the test suite with `pytest -q` which produced `9 passed` (all tests succeeded).  
- Attempted `python -m pycodestyle .` but `pycodestyle` is not installed in the environment (not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1232bab948324af0fe4fca37db840)